### PR TITLE
Fixed remaining reduce deprecation

### DIFF
--- a/re/ReForm.re
+++ b/re/ReForm.re
@@ -152,7 +152,7 @@ module Create = (Config: Config) => {
           },
           (
             self =>
-              self.reduce((_) => HandleFieldValidation((field, value)), ())
+              self.send(HandleFieldValidation((field, value)))
           ),
         )
       | HandleSubmit =>


### PR DESCRIPTION
"reduce" isn't allowed anymore since reason-react 0.4.0
https://github.com/reasonml/reason-react/blob/master/HISTORY.md#breaking-changes

Let me know if I need to change something!